### PR TITLE
Improved conversion routines and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 cps-auth.json
 cps_client.json
 
+results_*/
+
 # Created by https://www.gitignore.io/api/linux,macos,python,windows,pycharm+all,visualstudiocode,virtualenv
 # Edit at https://www.gitignore.io/?templates=linux,macos,python,windows,pycharm+all,visualstudiocode,virtualenv
 

--- a/deepsearch/__init__.py
+++ b/deepsearch/__init__.py
@@ -6,4 +6,4 @@ from .core import DeepSearchBearerTokenAuth, DeepSearchConfig, DeepSearchKeyAuth
 from .core.util._version import version
 from .cps import CpsApi, CpsApiClient
 from .cps.data_indices import utils
-from .documents import convert_document
+from .documents import convert_documents

--- a/deepsearch/core/cli/login.py
+++ b/deepsearch/core/cli/login.py
@@ -11,7 +11,7 @@ app = typer.Typer(invoke_without_command=True)
 @app.callback(help="Save authentication configuration")
 def save_auth(
     *,
-    host: str = typer.Option("https://cps.foc-deepsearch.zurich.ibm.com", prompt=True),
+    host: str = typer.Option("https://deepsearch-experience.res.ibm.com", prompt=True),
     email: str = typer.Option(..., prompt=True),
     api_key: str = typer.Option(..., prompt=True, hide_input=True),
     verify_ssl: bool = typer.Option(True, prompt=True),

--- a/deepsearch/cps/cli/data_indices_typer.py
+++ b/deepsearch/cps/cli/data_indices_typer.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import List
 
 import typer
 
@@ -106,6 +107,16 @@ def delete_data_index(
     return
 
 
+def get_urls(path: Path) -> List[str]:
+    """
+    Returns list of url from input file.
+    """
+
+    lines = path.read_text()
+    urls = [line.strip() for line in lines.split("\n") if line.strip() != ""]
+    return urls
+
+
 @app.command(name="upload", help="Upload files/urls to index", no_args_is_help=True)
 def upload_files(
     proj_key: str = PROJ_KEY,
@@ -116,6 +127,12 @@ def upload_files(
     """
     Upload pdfs, zips, or online documents to a data index in a project
     """
+
+    urls = None
+    if url is not None:
+        p = Path(url)
+        urls = get_urls(p) if p.exists() else [url]
+
     coords = ElasticProjectDataCollectionSource(proj_key=proj_key, index_key=index_key)
     utils.upload_files(coords=coords, url=url, local_file=local_file)
     return

--- a/deepsearch/cps/client/api.py
+++ b/deepsearch/cps/client/api.py
@@ -111,7 +111,12 @@ class CpsApi:
         Connect to CPS's API using a configured environment file
         """
 
-        config = DeepSearchConfig.parse_file(config_file_path())
+        config_file = config_file_path()
+        if not config_file.exists():
+            raise RuntimeError(
+                f"Config file {config_file} does not exist. Please configure your default authentication with `$ deepsearch login`"
+            )
+        config = DeepSearchConfig.parse_file(config_file)
 
         client = CpsApiClient(config)
 

--- a/deepsearch/documents/__init__.py
+++ b/deepsearch/documents/__init__.py
@@ -1,1 +1,1 @@
-from .core import convert_document
+from .core import convert_documents

--- a/deepsearch/documents/cli/main.py
+++ b/deepsearch/documents/cli/main.py
@@ -1,17 +1,28 @@
 from pathlib import Path, PosixPath
+from typing import List
 
 import typer
 
 from deepsearch.cps.cli.cli_options import LOCAL_FILE, PROJ_KEY, URL
 from deepsearch.documents.core.common_routines import WELCOME
-from deepsearch.documents.core.main import convert_document
+from deepsearch.documents.core.main import convert_documents
 
 app = typer.Typer(no_args_is_help=True)
 
 
+def get_urls(path: Path) -> List[str]:
+    """
+    Returns list of url from input file.
+    """
+
+    lines = path.read_text()
+    urls = [line.strip() for line in lines.split("\n") if line.strip() != ""]
+    return urls
+
+
 @app.command(
     name="convert",
-    help="Convert pdf documents using DeepSearch Technology",
+    help="Convert pdf documents using Deep Search Technology",
     no_args_is_help=True,
 )
 def convert(
@@ -20,12 +31,12 @@ def convert(
     local_file: Path = LOCAL_FILE,
 ):
     """
-    Document conversion via DeepSearch Technology.
+    Document conversion via Deep Search Technology.
 
     Inputs
     ------
     proj_key : string [REQUIRED]
-    Your DeepSearch CPS Project Key. Contact DeepSearch Developers to request one.
+    Your Deep Search CPS Project Key.
 
     url : string [OPTIONAL]
     For converting a document from the web, please provide its url.
@@ -36,7 +47,14 @@ def convert(
 
     NOTE: Either url or local_file should be supplied.
     """
-    convert_document(proj_key=proj_key, url=url, local_file=local_file)
+    typer.echo(WELCOME)
+
+    urls = None
+    if url is not None:
+        p = Path(url)
+        urls = get_urls(p) if p.exists() else [url]
+
+    documents = convert_documents(proj_key=proj_key, url=urls, local_file=local_file)
     return
 
 

--- a/deepsearch/documents/core/__init__.py
+++ b/deepsearch/documents/core/__init__.py
@@ -1,1 +1,1 @@
-from .main import convert_document
+from .main import convert_documents

--- a/deepsearch/documents/core/common_routines.py
+++ b/deepsearch/documents/core/common_routines.py
@@ -1,19 +1,6 @@
-# # WELCOME = """
-#     __        __   _                            _          _   _
-#     \ \      / /__| | ___ ___  _ __ ___   ___  | |_ ___   | |_| |__   ___
-#      \ \ /\ / / _ \ |/ __/ _ \| '_ ` _ \ / _ \ | __/ _ \  | __| '_ \ / _ \
-#       \ V  V /  __/ | (_| (_) | | | | | |  __/ | || (_) | | |_| | | |  __/
-#        \_/\_/ \___|_|\___\___/|_| |_| |_|\___|  \__\___/   \__|_| |_|\___|
-#   ____                 ____                      _       _____           _ _    _ _
-#  |  _ \  ___  ___ _ __/ ___|  ___  __ _ _ __ ___| |__   |_   _|__   ___ | | | _(_) |_
-#  | | | |/ _ \/ _ \ '_ \___ \ / _ \/ _` | '__/ __| '_ \    | |/ _ \ / _ \| | |/ / | __|
-#  | |_| |  __/  __/ |_) |__) |  __/ (_| | | | (__| | | |   | | (_) | (_) | |   <| | |_
-#  |____/ \___|\___| .__/____/ \___|\__,_|_|  \___|_| |_|   |_|\___/ \___/|_|_|\_\_|\__|
-#                  |_|
-# """
 dashes = f"{'-'*86}"
-WELCOME = f"{dashes}\n{'':>26}Welcome to the DeepSearch Toolkit\n{dashes}"
-ERROR_MSG = f"{dashes}\nSuggestion:\n(1) Check your input.\n(2) Contact DeepSearch developers if problem persists.\n{dashes}"
+WELCOME = f"{dashes}\n{'':>26}Welcome to the Deep Search Toolkit\n{dashes}"
+ERROR_MSG = f"{dashes}\nSuggestion:\n(1) Check your input.\n(2) Contact Deep Search developers if problem persists.\n{dashes}"
 # left justified padding for uniform progress bars
 progressbar_padding = 20
 success_message = "Whoa... it is done. Until next time, Ciao!"

--- a/deepsearch/documents/core/convert.py
+++ b/deepsearch/documents/core/convert.py
@@ -12,7 +12,6 @@ from deepsearch.cps.apis import public as sw_client
 from deepsearch.cps.apis.public.models.temporary_upload_file_result import (
     TemporaryUploadFileResult,
 )
-from deepsearch.cps.cli.cli_options import PROJ_KEY, URL
 from deepsearch.cps.client.api import CpsApi
 
 from .common_routines import ERROR_MSG, progressbar_padding
@@ -53,11 +52,10 @@ def download_url(url: str, save_path: Path, chunk_size=128):
     return
 
 
-def check_single_task_status(ccs_proj_key: str, task_id: str):
+def check_single_task_status(api: CpsApi, ccs_proj_key: str, task_id: str):
     """
     Check status of individual tasks.
     """
-    api = CpsApi.default_from_env()
     url_host = api.client.swagger_client.configuration.host
     url_linked_ccs = url_host.rstrip("/public/v1").rstrip("cps") + "linked-ccs"
     current_state = False
@@ -70,39 +68,44 @@ def check_single_task_status(ccs_proj_key: str, task_id: str):
     return request_status
 
 
-def get_ccs_project_key(cps_proj_key: str):
+def get_ccs_project_key(api: CpsApi, cps_proj_key: str):
     """
     Given a cps project key, returns ccs project key and collection name.
     """
-    api = CpsApi.default_from_env()
     sw_api = sw_client.ProjectApi(api.client.swagger_client)
-    try:
-        request_ccs_project_key = sw_api.get_project_default_values(
-            proj_key=cps_proj_key
-        )
-        ccs_proj_key = request_ccs_project_key.ccs_project.proj_key
-        collection_name = request_ccs_project_key.ccs_project.collection_name
 
-    except requests.exceptions.HTTPError as err:
-        print(f"HTTPError {err}.\n{ERROR_MSG}")
-        print("Aborting!")
-        return
-    except KeyError as err:
-        print(f"Error: Received unexpected response.\n{ERROR_MSG}")
-        print("Aborting!")
-        return
-    except urllib3.exceptions.MaxRetryError as err:
-        print(f"Error: err.\n{ERROR_MSG}")
-        print("Aborting!")
-        return
+    # TODO: Do we actually need to handle these exceptions here?
+    # If yes, let's chain a custom-exception, e.g. CcsClientException
+
+    # try:
+    #     request_ccs_project_key = sw_api.get_project_default_values(
+    #         proj_key=cps_proj_key
+    #     )
+    #     ccs_proj_key = request_ccs_project_key.ccs_project.proj_key
+    #     collection_name = request_ccs_project_key.ccs_project.collection_name
+    # except requests.exceptions.HTTPError as err:
+    #     print(f"HTTPError {err}.\n{ERROR_MSG}")
+    #     print("Aborting!")
+    #     return
+    # except KeyError as err:
+    #     print(f"Error: Received unexpected response.\n{ERROR_MSG}")
+    #     print("Aborting!")
+    #     return
+    # except urllib3.exceptions.MaxRetryError as err:
+    #     print(f"Error: err.\n{ERROR_MSG}")
+    #     print("Aborting!")
+    #     return
+
+    request_ccs_project_key = sw_api.get_project_default_values(proj_key=cps_proj_key)
+    ccs_proj_key = request_ccs_project_key.ccs_project.proj_key
+    collection_name = request_ccs_project_key.ccs_project.collection_name
     return (ccs_proj_key, collection_name)
 
 
-def get_converted_doc(ccs_proj_key: str, task_id: str):
+def get_converted_doc(api: CpsApi, ccs_proj_key: str, task_id: str):
     """
     Download converted document
     """
-    api = CpsApi.default_from_env()
     url_host = api.client.swagger_client.configuration.host
     url_linked_ccs = url_host.rstrip("/public/v1").rstrip("cps") + "linked-ccs"
     url_result = f"{url_linked_ccs}{url_public_apis}/projects/{ccs_proj_key}/document_conversions/{task_id}/result"
@@ -125,20 +128,21 @@ def get_converted_doc(ccs_proj_key: str, task_id: str):
 
 
 def submit_url_for_conversion(
-    cps_proj_key: str = PROJ_KEY,
-    url: str = URL,
+    api: CpsApi,
+    cps_proj_key: str,
+    url: str,
 ) -> str:
     """
     Convert an online pdf using DeepSearch Technology.
     """
-    api = CpsApi.default_from_env()
-
     # define urls
     url_host = api.client.swagger_client.configuration.host
     url_linked_ccs = url_host.rstrip("/public/v1").rstrip("cps") + "linked-ccs"
 
     # get ccs project key and collection name
-    ccs_proj_key, collection_name = get_ccs_project_key(cps_proj_key=cps_proj_key)
+    ccs_proj_key, collection_name = get_ccs_project_key(
+        api=api, cps_proj_key=cps_proj_key
+    )
 
     # submit conversion request
     payload = make_payload(url, collection_name)
@@ -160,7 +164,7 @@ def submit_url_for_conversion(
 
 
 def send_files_for_conversion(
-    cps_proj_key: str, local_file: Path, root_dir: Path
+    api: CpsApi, cps_proj_key: str, local_file: Path, root_dir: Path
 ) -> list:
     """
     Send multiple files for conversion.
@@ -193,11 +197,11 @@ def send_files_for_conversion(
         for single_zip in files_zip:
             # upload file
             private_download_url = upload_single_file(
-                cps_proj_key=cps_proj_key, file=Path(single_zip)
+                api=api, cps_proj_key=cps_proj_key, file=Path(single_zip)
             )
             # submit url for conversion
             task_id = submit_url_for_conversion(
-                cps_proj_key=cps_proj_key, url=private_download_url
+                api=api, cps_proj_key=cps_proj_key, url=private_download_url
             )
             task_ids.append(task_id)
             progress.update(1)
@@ -205,15 +209,16 @@ def send_files_for_conversion(
     return task_ids
 
 
-def check_status_running_tasks(cps_proj_key: str, task_ids) -> List[str]:
+def check_status_running_tasks(api: CpsApi, cps_proj_key: str, task_ids) -> List[str]:
     """
     Check status of multiple running tasks and display progress with progress bar.
     """
     count_total = len(task_ids)
-    api = CpsApi.default_from_env()
 
     # get ccs proj keys
-    ccs_proj_key, collection_name = get_ccs_project_key(cps_proj_key=cps_proj_key)
+    ccs_proj_key, collection_name = get_ccs_project_key(
+        api=api, cps_proj_key=cps_proj_key
+    )
 
     statuses = []
 
@@ -222,7 +227,7 @@ def check_status_running_tasks(cps_proj_key: str, task_ids) -> List[str]:
     ) as progress:
         for task_id in task_ids:
             request_status = check_single_task_status(
-                ccs_proj_key=ccs_proj_key, task_id=task_id
+                api=api, ccs_proj_key=ccs_proj_key, task_id=task_id
             )
             if request_status.json()["done"]:
                 progress.update(1)
@@ -231,16 +236,19 @@ def check_status_running_tasks(cps_proj_key: str, task_ids) -> List[str]:
     return statuses
 
 
-def download_converted_docs(cps_proj_key: str, task_ids: list, root_dir: Path):
+def download_converted_docs(
+    api: CpsApi, cps_proj_key: str, task_ids: list, root_dir: Path
+):
     """
     Download all converted documents
     """
-    api = CpsApi.default_from_env()
     url_host = api.client.swagger_client.configuration.host
     url_linked_ccs = url_host.rstrip("/public/v1").rstrip("cps") + "linked-ccs"
 
     # get ccs proj keys
-    ccs_proj_key, collection_name = get_ccs_project_key(cps_proj_key=cps_proj_key)
+    ccs_proj_key, collection_name = get_ccs_project_key(
+        api=api, cps_proj_key=cps_proj_key
+    )
 
     # setup result directory
     result_dir = root_dir
@@ -273,12 +281,11 @@ def download_converted_docs(cps_proj_key: str, task_ids: list, root_dir: Path):
     return
 
 
-def upload_single_file(cps_proj_key: str, file: Path) -> str:
+def upload_single_file(api: CpsApi, cps_proj_key: str, file: Path) -> str:
     """
     Uploads a single file. Return internal download url.
     """
     filename = os.path.basename(file)
-    api = CpsApi.default_from_env()
     # url_host = api.client.swagger_client.configuration.host
     sw_api = sw_client.UploadsApi(api.client.swagger_client)
 
@@ -299,7 +306,9 @@ def upload_single_file(cps_proj_key: str, file: Path) -> str:
     return private_download_url
 
 
-def send_urls_for_conversion(cps_proj_key: str, urls: List[str]) -> List[Any]:
+def send_urls_for_conversion(
+    api: CpsApi, cps_proj_key: str, urls: List[str]
+) -> List[Any]:
     """
     Send multiple online documents for conversion.
     """
@@ -310,7 +319,9 @@ def send_urls_for_conversion(cps_proj_key: str, urls: List[str]) -> List[Any]:
         desc=f'{"Submitting input:":<{progressbar_padding}}',
     ) as progress:
         for url in urls:
-            task_id = submit_url_for_conversion(cps_proj_key=cps_proj_key, url=url)
+            task_id = submit_url_for_conversion(
+                api=api, cps_proj_key=cps_proj_key, url=url
+            )
             task_ids.append(task_id)
             progress.update(1)
     return task_ids

--- a/deepsearch/documents/core/create_report.py
+++ b/deepsearch/documents/core/create_report.py
@@ -9,8 +9,6 @@ from typing import Any, List
 
 import typer
 
-from .common_routines import WELCOME
-
 
 def report_urls(
     root_dir: Path, urls: List[str], statuses: List[str], task_ids: List[str]

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ Note: Managing and querying knowledge graphs is only enabled on dedicated Deep S
 
 |    | Name              | Description |
 | -- | ----------------- | ----------- |
+| 1. | [Convert_Documents.ipynb](notebooks/Convert_Documents.ipynb) | Full example on programmatic document conversion |
 | 1. | [Query_NodeData.ipynb](notebooks/Query_NodeData.ipynb) | Simple query search for terms and output the text containing them |
 | 2. | [Query_WF_Execute.ipynb](notebooks/Query_WF_Execute.ipynb) | Run query copied from the UI editor |
 | 3. | Query_FTS.ipynb | Using the FullTextSearch functionality |

--- a/examples/notebooks/Convert_Documents.ipynb
+++ b/examples/notebooks/Convert_Documents.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "502cdef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import deepsearch as ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0431ea2c",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "In this example, we initialize the Deep Search client from the credentials\n",
+    "contained in the file `cps-auth.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0e5d3ca1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth_filename = \"cps-auth.json\" # this file should be populated with the credentials\n",
+    "auth_data = json.load(open(auth_filename))\n",
+    "\n",
+    "auth = ds.DeepSearchKeyAuth(\n",
+    "    username=auth_data[\"email\"],\n",
+    "    api_key=auth_data[\"api_key\"],\n",
+    ")\n",
+    "\n",
+    "config = ds.DeepSearchConfig(\n",
+    "    # the host of the Deep Search instance you are using\n",
+    "    host=\"https://deepsearch-experience.res.ibm.com\",\n",
+    "\n",
+    "    # if needed, the validation of the SSL certificate can be avoided\n",
+    "    #verify_ssl=True, \n",
+    "\n",
+    "    # auth credentials\n",
+    "    auth=auth,\n",
+    ")\n",
+    "\n",
+    "client = ds.CpsApiClient(config)\n",
+    "api = ds.CpsApi(client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f09bbd4",
+   "metadata": {},
+   "source": [
+    "## Convert your first file\n",
+    "\n",
+    "\n",
+    "In the next block we convert our first document. As an input, we use a URL to a PDF file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c61d9bdb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submitting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.29s/it]\n",
+      "Converting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:24<00:00, 24.55s/it]\n",
+      "Downloading result: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.55s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total online documents:            0001\n",
+      "Successfully converted documents:  0001(100%)\n",
+      "Run time:                          28.20 seconds\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "PROJ_KEY=\"1234567890abcdefghijklmnopqrstvwyz123456\"\n",
+    "documents = ds.convert_documents(api=api, proj_key=PROJ_KEY, url=\"https://arxiv.org/pdf/2206.00785.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2dc1847e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Do something with documents\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "535456af",
+   "metadata": {},
+   "source": [
+    "## More convert options\n",
+    "\n",
+    "The Deep Search toolkit provides helper functions which can convert documents from different type of inputs.\n",
+    "\n",
+    "- From a single url\n",
+    "- From a list of urls. In this case, the toolkit will launch a batch processing with all tasks.\n",
+    "- From a local PDF file\n",
+    "- From a local zip archive containing PDF files.\n",
+    "- From a local local folder containing PDF files. In this case, the toolkit is packaging the files into batches and creates multiple zip archives.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7126c7b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submitting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.11it/s]\n",
+      "Converting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:52<00:00, 26.30s/it]\n",
+      "Downloading result: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:03<00:00,  1.53s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total online documents:            0002\n",
+      "Successfully converted documents:  0002(100%)\n",
+      "Run time:                          58.49 seconds\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Process multiple urls\n",
+    "\n",
+    "PROJ_KEY=\"1234567890abcdefghijklmnopqrstvwyz123456\"\n",
+    "documents = ds.convert_documents(api=api, proj_key=PROJ_KEY, url=[\"https://arxiv.org/pdf/2206.00785.pdf\", \"https://arxiv.org/pdf/2206.01062.pdf\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "72a81849",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing input:   : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 258.46it/s]\n",
+      "Submitting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.46s/it]\n",
+      "Converting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:55<00:00, 55.90s/it]\n",
+      "Downloading result: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.37s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total files (pdf+zip):             0001\n",
+      "Total batches:                     0001\n",
+      "Successfully converted batches:    0001(100%)\n",
+      "Run time:                          1.02 minutes\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Process local file\n",
+    "\n",
+    "PROJ_KEY=\"1234567890abcdefghijklmnopqrstvwyz123456\"\n",
+    "documents = ds.convert_documents(api=api, proj_key=PROJ_KEY, local_file=\"/Users/dol/Downloads/redbooks-xsmall/redp5004.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7dc33e5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing input:   : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 349.58it/s]\n",
+      "Submitting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.58s/it]\n",
+      "Converting input:   : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [01:09<00:00, 69.69s/it]\n",
+      "Downloading result: : 2it [00:03,  1.59s/it]                                                                                                                                                                                       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total files (pdf+zip):             0002\n",
+      "Total batches:                     0001\n",
+      "Successfully converted batches:    0001(100%)\n",
+      "Run time:                          1.29 minutes\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Process folder of files\n",
+    "\n",
+    "PROJ_KEY=\"1234567890abcdefghijklmnopqrstvwyz123456\"\n",
+    "documents = ds.convert_documents(api=api, proj_key=PROJ_KEY, local_file=\"/Users/dol/Downloads/redbooks-xsmall\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03d11356",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #4, partially address #5.

- Propagate `api` object and avoid re-initializing default settings
- Complete document conversion example