### PR TITLE
Fix for getting deepsearch client version

### DIFF
--- a/deepsearch/core/util/_version.py
+++ b/deepsearch/core/util/_version.py
@@ -16,7 +16,7 @@ def get_server_version():
 def get_client_version():
     import importlib.metadata
 
-    return importlib.metadata.version("deepsearch")
+    return importlib.metadata.version("deepsearch-toolkit")
 
 
 def version() -> VersionSpecs:


### PR DESCRIPTION
Installed into a dedicated conda environment via pip

Fixes error:

```
$ deepsearch version
Traceback (most recent call last):
  File "/Users/someuser/miniconda3/envs/deepsearch/bin/deepsearch", line 8, in <module>
    sys.exit(app())
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/typer/main.py", line 500, in wrapper
    return callback(**use_params)  # type: ignore
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/deepsearch/core/cli/main.py", line 15, in get_version
    versions = ds.version()
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/deepsearch/core/util/_version.py", line 24, in version
    client=get_client_version(),
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/site-packages/deepsearch/core/util/_version.py", line 19, in get_client_version
    return importlib.metadata.version("deepsearch")
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/importlib/metadata.py", line 530, in version
    return distribution(distribution_name).version
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/importlib/metadata.py", line 503, in distribution
    return Distribution.from_name(distribution_name)
  File "/Users/someuser/miniconda3/envs/deepsearch/lib/python3.8/importlib/metadata.py", line 177, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: deepsearch

```

Signed-off-by: Daniel Blankenberg <dan.blankenberg@gmail.com>