### PR TITLE
Adjusting base URL

### DIFF
--- a/deepsearch/core/cli/login.py
+++ b/deepsearch/core/cli/login.py
@@ -11,7 +11,7 @@ app = typer.Typer(invoke_without_command=True)
 @app.callback(help="Save authentication configuration")
 def save_auth(
     *,
-    host: str = typer.Option("https://deepsearch-experience.res.ibm.com", prompt=True),
+    host: str = typer.Option("https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud", prompt=True),
     email: str = typer.Option(..., prompt=True),
     api_key: str = typer.Option(..., prompt=True, hide_input=True),
     verify_ssl: bool = typer.Option(True, prompt=True),

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -15,7 +15,7 @@ After registering with [Deep Search](https://ds4sd.github.io/), you can obtain y
     ```console
     $ deepsearch login
 
-    Host [https://deepsearch-experience.res.ibm.com]:       #(1)
+    Host [https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud]:       #(1)
     Email:                                                  #(2)
     Api key:                                                #(3)
     ```
@@ -40,7 +40,7 @@ After registering with [Deep Search](https://ds4sd.github.io/), you can obtain y
     # auth = DeepSearchAuth(bearer_token="TOKEN")
 
     config = ds.DeepSearchConfig(
-        host="https://deepsearch-experience.res.ibm.com",
+        host="https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud",
         auth=auth,
     )
 

--- a/docs/guide/apis.md
+++ b/docs/guide/apis.md
@@ -28,7 +28,7 @@ auth = DeepSearchKeyAuth(
 )
 
 config = DeepSearchConfig(
-    host="https://deepsearch-experience.res.ibm.com",
+    host="https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud",
     auth=auth,
     verify_ssl=False,
 )
@@ -49,8 +49,8 @@ Another option is interacting with the CPS API directly using the endpoints. CPS
 - Public API: `https://{HOST}/api/cps/public/v1/ui/`
 
 For example:
-- User API: https://deepsearch-experience.res.ibm.com/api/cps/user/v1/ui/
-- Public API: https://deepsearch-experience.res.ibm.com/api/cps/public/v1/ui/
+- User API: https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud/api/cps/user/v1/ui/
+- Public API: https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud/api/cps/public/v1/ui/
 
 
 Once find the endpoint for your request, you can use it with this example code.
@@ -65,7 +65,7 @@ auth = DeepSearchKeyAuth(
 )
 
 config = DeepSearchConfig(
-    host="https://deepsearch-experience.res.ibm.com",
+    host="https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud",
     auth=auth,
     verify_ssl=False,
 )

--- a/examples/notebooks/Convert_Documents.ipynb
+++ b/examples/notebooks/Convert_Documents.ipynb
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "host = \"https://deepsearch-experience.res.ibm.com\"\n",
+    "host = \"https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud\"\n",
     "proj = \"1234567890abcdefghijklmnopqrstvwyz123456\"\n",
     "\n",
     "username = \"<fill-in-your-username>\"\n",
@@ -160,7 +160,7 @@
     "\n",
     "config = ds.DeepSearchConfig(\n",
     "    # the host of the Deep Search instance you are using\n",
-    "    host=\"https://deepsearch-experience.res.ibm.com\",\n",
+    "    host=\"https://deepsearch-ext-v2-535206b87b82b5365d9d6671fbc19165-0000.us-south.containers.appdomain.cloud\",\n",
     "\n",
     "    # if needed, the validation of the SSL certificate can be avoided\n",
     "    # verify_ssl=True, \n",


### PR DESCRIPTION
Tried to log in copying and pasting from documentation and I was getting raise RuntimeError("The API Key or User is invalid.").
I noticed that with the new URL I was able to use the python package without problems.

Not sure if this is the right fix/URL. If not I can close this one without problem.

edit: just noticed that maybe my URL is different because I'm running as a registered/approved user. so maybe this PR is not useful.
