### PR TITLE
incorrect success messages with tqdm progress bar tasks

### DIFF
--- a/deepsearch/cps/data_indices/utils.py
+++ b/deepsearch/cps/data_indices/utils.py
@@ -74,6 +74,11 @@ def process_url_input(
     task_ids = []
     # submit urls
     count_urls = len(urls)
+
+    # Check if there are valid targets to iterate over
+    if count_urls == 0:
+        print("No urls resolved from input")
+        return
     with tqdm(
         total=count_urls,
         desc=f"{'Submitting input:': <{progressbar.padding}}",
@@ -133,6 +138,10 @@ def process_local_file(
     # container for task_ids
     task_ids = []
 
+    # Check if there are valid targets to iterate over
+    if count_total_files == 0:
+        print("No files resolved from input")
+        return
     # start loop
     with tqdm(
         total=count_total_files,

--- a/deepsearch/documents/core/convert.py
+++ b/deepsearch/documents/core/convert.py
@@ -116,6 +116,11 @@ def send_files_for_conversion(
     # container for task_ids
     task_ids = []
 
+    # Check if there are valid targets to iterate over
+    if len(files_zip) == 0:
+        print("No files resolved from input")
+        return []
+
     # start loop
     with tqdm(
         total=len(files_zip),
@@ -162,6 +167,11 @@ def check_status_running_tasks(
         api=api, cps_proj_key=cps_proj_key
     )
     statuses = []
+
+    # Check if there are valid targets to iterate over
+    if count_total == 0:
+        print("No task_ids resolved from input")
+        return []
 
     with tqdm(
         total=count_total,
@@ -227,6 +237,11 @@ def download_converted_documents(
         shows progress bar if True
     """
 
+    # Check if there are valid targets to iterate over
+    if len(download_urls) == 0:
+        print("No urls resolved from input")
+        return
+
     with tqdm(
         total=len(download_urls),
         desc=f"{'Downloading result:': <{progressbar.padding}}",
@@ -280,6 +295,12 @@ def send_urls_for_conversion(
     """
     count_urls = len(urls)
     task_ids = []
+
+    # Check if there are valid targets to iterate over
+    if count_urls == 0:
+        print("No urls resolved from input")
+        return []
+
     with tqdm(
         total=count_urls,
         desc=f"{'Submitting input:': <{progressbar.padding}}",

--- a/deepsearch/documents/core/create_report.py
+++ b/deepsearch/documents/core/create_report.py
@@ -71,6 +71,11 @@ def get_multiple_reports(
         writer = csv.writer(csvfile)
         writer.writerow(["batch_number", "task_id", "status", "document"])
 
+        # Check if there are valid targets to iterate over
+        if len(task_ids) == 0:
+            print("No task_ids resolved from input")
+            return
+
         # start loop
         with tqdm(
             total=len(task_ids),

--- a/deepsearch/documents/core/utils.py
+++ b/deepsearch/documents/core/utils.py
@@ -103,6 +103,11 @@ def batch_single_files(
     # catch all filenames and batch names
     batched_files = []
 
+    # Check if there are valid targets to iterate over
+    if len(files_to_upload) == 0:
+        print("No files resolved from input")
+        return []
+
     if len(files_to_upload) != 0:
         with tqdm(
             total=len(files_to_upload),


### PR DESCRIPTION
The issue arose from tqdm automatically saying success upon ending its task in conjunction with the inputs to a command resolving to an empty list of tasks.

for example to upload files, upon adding a non existing file the resulting "task_list" would be an empty list wich tqdm would grab, complete instantly and print out success

The solution applied to all (8) instances of this was to add a check for the list size, before dispatching tqdm, if the size was 0 print some error message and return out