### PR TITLE
fix: compatibility with platformdirs >= 4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1754,18 +1754,19 @@ testing = ["pytest", "pytest-cov", "wheel"]
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "4.3.2"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
+    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -3307,4 +3308,4 @@ api = ["anyio", "fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e9b2eddeda51d9b024f25d21d9d06b4333b39cb832f444e31c6242aa4160e791"
+content-hash = "7137c5e34d585d2a9e26788597e85998096a9d2687952097872f9da507ee0d77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pydantic-settings = "^2.4.0"
 python-dotenv = "^1.0.0"
 requests = "^2.27.1"
 typer = {extras = ["all"], version = ">=0.9.0, <1.0.0"}
-platformdirs = "^3.5.1"
+platformdirs = ">=3.5.1,<5.0.0"
 tabulate = ">=0.8.9, <1.0.0"
 pluggy = "^1.0.0"
 tqdm = "^4.64.0"


### PR DESCRIPTION
The only [breaking change](https://github.com/tox-dev/platformdirs/releases/tag/4.0.0) reported by `platformdirs` is for the `cache_dir` which we are not using.

Locally, after the upgrade, `deepsearch profile list` is still listing all previous profiles.